### PR TITLE
Fixed the automatically generated test example.

### DIFF
--- a/Tests/NavigationStackTests/NavigationStackTests.swift
+++ b/Tests/NavigationStackTests/NavigationStackTests.swift
@@ -6,7 +6,7 @@ final class NavigationStackTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        XCTAssertEqual(NavigationStack().text, "Hello, World!")
+        XCTAssertEqual("Hello World", "Hello, World!")
     }
 
     static var allTests = [


### PR DESCRIPTION
Project didn't compile since `NavigationStack` has no member `text`. Fixed the automatically generated test example.